### PR TITLE
Nestable structs for ecql

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -107,7 +107,18 @@ func MapTable(i interface{}) (map[string]interface{}, Table) {
 
 	columns := make(map[string]interface{})
 	for _, col := range table.Columns {
-		field := v.Field(col.Position)
+		var field reflect.Value
+		for _, p := range col.Position {
+			field = v.Field(p)
+			next := field
+			if field.CanAddr() {
+				next = field.Addr()
+			}
+			if next.Kind() != reflect.Struct {
+				break
+			}
+			v = structOf(next.Interface())
+		}
 		if field.CanAddr() {
 			columns[col.Name] = field.Addr().Interface()
 		} else {
@@ -138,7 +149,19 @@ func BindTable(i interface{}) ([]interface{}, map[string]interface{}, Table) {
 	columns := make([]interface{}, len(table.Columns))
 	mapping := make(map[string]interface{})
 	for i, col := range table.Columns {
-		field := v.Field(col.Position)
+		var field reflect.Value
+		for _, p := range col.Position {
+			field = v.Field(p)
+			next := field
+			if field.CanAddr() {
+				next = field.Addr()
+			}
+			if next.Kind() != reflect.Struct {
+				break
+			}
+			v = structOf(next.Interface())
+		}
+
 		columns[i] = field.Interface()
 		mapping[col.Name] = columns[i]
 	}
@@ -184,6 +207,24 @@ func register(i interface{}) Table {
 
 	for i, n := 0, t.NumField(); i < n; i++ {
 		field := t.Field(i)
+
+		// Embed fields from anonymous structs--but not at the expense of explicit tags
+		if field.Anonymous {
+			_, tt := MapTable(v.Field(i).Interface())
+			if len(tt.Name) > 0 && len(table.Name) == 0 {
+				table.Name = tt.Name
+			}
+			if len(tt.KeyColumns) > 0 && len(table.KeyColumns) == 0 {
+				table.KeyColumns = tt.KeyColumns
+			}
+			if len(tt.Columns) > 0 {
+				for _, col := range tt.Columns {
+					col.Position = append([]int{i}, col.Position...)
+					table.Columns = append(table.Columns, col)
+				}
+			}
+		}
+
 		// Get table if available
 		name := field.Tag.Get(TAG_TABLE)
 		if name != "" {
@@ -202,7 +243,7 @@ func register(i interface{}) Table {
 			name = strings.ToLower(field.Name)
 		}
 		if name != "-" {
-			table.Columns = append(table.Columns, Column{name, i})
+			table.Columns = append(table.Columns, Column{name, []int{i}})
 		}
 	}
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -36,7 +36,7 @@ func TestRegister(t *testing.T) {
 		assert.Len(t, table.Columns, 4)
 		for i := range testStructNames {
 			assert.Equal(t, testStructNames[i], table.Columns[i].Name)
-			assert.Equal(t, i, table.Columns[i].Position)
+			assert.Equal(t, []int{i}, table.Columns[i].Position)
 		}
 	}
 }

--- a/table.go
+++ b/table.go
@@ -24,10 +24,11 @@ type Table struct {
 }
 
 // Column contains the information of a column in a table required
-// to create a map for it.
+// to create a map for it.  Every element of position represents an
+// anonymous nesting--with a single position representing an immediate named field
 type Column struct {
 	Name     string
-	Position int
+	Position []int
 }
 
 func (t *Table) BuildQuery(qt queryType) (string, error) {

--- a/table.go
+++ b/table.go
@@ -24,8 +24,8 @@ type Table struct {
 }
 
 // Column contains the information of a column in a table required
-// to create a map for it.  Every element of position represents an
-// anonymous nesting--with a single position representing an immediate named field
+// to create a map for it.
+// Every element of position represents its order in a hierarchy of nested structs
 type Column struct {
 	Name     string
 	Position []int


### PR DESCRIPTION
Setting anon structs to serialize similar to how json works in go--so nested anon struct can set table and keys, while wrapping struct may represent different views of data.