### PR TITLE
Revert "Nestable structs for ecql"

### DIFF
--- a/mapper_test.go
+++ b/mapper_test.go
@@ -36,7 +36,7 @@ func TestRegister(t *testing.T) {
 		assert.Len(t, table.Columns, 4)
 		for i := range testStructNames {
 			assert.Equal(t, testStructNames[i], table.Columns[i].Name)
-			assert.Equal(t, []int{i}, table.Columns[i].Position)
+			assert.Equal(t, i, table.Columns[i].Position)
 		}
 	}
 }

--- a/table.go
+++ b/table.go
@@ -25,10 +25,9 @@ type Table struct {
 
 // Column contains the information of a column in a table required
 // to create a map for it.
-// Every element of position represents its order in a hierarchy of nested structs
 type Column struct {
 	Name     string
-	Position []int
+	Position int
 }
 
 func (t *Table) BuildQuery(qt queryType) (string, error) {


### PR DESCRIPTION
Reverts maraino/ecql#6

TestDelete fails with a panic:
```
--- FAIL: TestDelete (0.04s)
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method [recovered]
	panic: reflect.Value.Interface: cannot return value obtained from unexported field or method

goroutine 130 [running]:
testing.tRunner.func1(0xc420219040)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:622 +0x29d
panic(0x1328540, 0xc420231600)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
reflect.valueInterface(0x1361220, 0xc420227ba0, 0xb6, 0x1, 0x0, 0x3)
	/usr/local/Cellar/go/1.8.1/libexec/src/reflect/value.go:936 +0x1a5
reflect.Value.Interface(0x1361220, 0xc420227ba0, 0xb6, 0x19, 0x0)
	/usr/local/Cellar/go/1.8.1/libexec/src/reflect/value.go:925 +0x44
github.com/maraino/ecql.BindTable(0x1362ba0, 0xc420227b80, 0x38, 0xc420227b80, 0x0, 0x4, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/mariano/go/src/github.com/maraino/ecql/mapper.go:168 +0x4bb
github.com/maraino/ecql.(*SessionImpl).Set(0xc420160058, 0x1362ba0, 0xc420227b80, 0xc420227b80, 0x0)
	/Users/mariano/go/src/github.com/maraino/ecql/ecql.go:63 +0x4d
github.com/maraino/ecql.TestDelete(0xc420219040)
	/Users/mariano/go/src/github.com/maraino/ecql/integration_test.go:325 +0x30c
testing.tRunner(0xc420219040, 0x13b53f8)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:697 +0x2ca
exit status 2
```