### PR TITLE
move away from gocql's derpericated batch onto the session one.

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -16,7 +16,7 @@ type BatchImpl struct {
 func NewBatch(sess *SessionImpl, typ gocql.BatchType) Batch {
 	return &BatchImpl{
 		session: sess,
-		batch:   gocql.NewBatch(typ),
+		batch:   sess.NewBatch(typ),
 	}
 }
 


### PR DESCRIPTION
Hey.  We hit an issue where the Batch ecql is using was deprecated in gocql and isn't properly set up anymore.  
Simple fix to move to the supported gocql Batch.